### PR TITLE
Add manual JS component framework

### DIFF
--- a/diagnose/AGENTS.md
+++ b/diagnose/AGENTS.md
@@ -1,0 +1,6 @@
+This project hosts a simple PHP server and JavaScript client.
+
+**Testing**:
+- Start the PHP built-in server: `php -S localhost:8000 -t server index.php &`
+- Run: `curl -s http://localhost:8000/api/hello`
+- Ensure the output contains `"message"`.

--- a/diagnose/README.md
+++ b/diagnose/README.md
@@ -1,0 +1,13 @@
+# Diagnose Project
+
+This subproject contains a PHP server with a static JavaScript client. The server exposes an API endpoint at `/api/hello` and serves the client files from the `client` directory. The client demonstrates a small component framework with animations.
+
+## Running
+
+From the `diagnose` directory, start the built-in PHP server:
+
+```bash
+php -S localhost:8000 -t server index.php
+```
+
+Then open [http://localhost:8000](http://localhost:8000) in your browser or run the `curl` command described in `AGENTS.md`.

--- a/diagnose/client/app.js
+++ b/diagnose/client/app.js
@@ -1,0 +1,38 @@
+window.addEventListener('DOMContentLoaded', () => {
+  class HelloComponent extends Framework.Component {
+    constructor(root) {
+      super(root);
+      this.message = '';
+    }
+
+    async load() {
+      try {
+        const res = await fetch('/api/hello');
+        const data = await res.json();
+        this.message = data.message;
+      } catch (err) {
+        this.message = 'Error: ' + err;
+      }
+      this.refresh();
+    }
+
+    template() {
+      return `<div class="hello">${this.message}</div>`;
+    }
+
+    afterRender() {
+      const el = this.root.querySelector('.hello');
+      if (el) {
+        Framework.animate(el, [
+          { opacity: 0, transform: 'translateY(-20px)' },
+          { opacity: 1, transform: 'translateY(0)' }
+        ], { duration: 500, fill: 'forwards', easing: 'ease-out' });
+      }
+    }
+  }
+
+  const root = document.getElementById('result');
+  const hello = new HelloComponent(root);
+  hello.mount();
+  hello.load();
+});

--- a/diagnose/client/framework.js
+++ b/diagnose/client/framework.js
@@ -1,0 +1,28 @@
+(() => {
+  class Component {
+    constructor(root) {
+      this.root = root;
+    }
+
+    mount() {
+      this.refresh();
+    }
+
+    refresh() {
+      this.root.innerHTML = this.template();
+      this.afterRender();
+    }
+
+    template() {
+      return '';
+    }
+
+    afterRender() {}
+  }
+
+  function animate(element, keyframes, options) {
+    return element.animate(keyframes, options);
+  }
+
+  window.Framework = { Component, animate };
+})();

--- a/diagnose/client/index.html
+++ b/diagnose/client/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Diagnose Client</title>
+  <script src="framework.js"></script>
+  <script src="app.js"></script>
+  <style>
+    #result { min-height: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Diagnose Client</h1>
+  <div id="result"></div>
+</body>
+</html>

--- a/diagnose/server/index.php
+++ b/diagnose/server/index.php
@@ -1,0 +1,20 @@
+<?php
+$uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
+if (strpos($uri, '/api/hello') === 0) {
+    header('Content-Type: application/json');
+    echo json_encode(['message' => 'Hello from API']);
+    return;
+}
+
+$clientBase = realpath(__DIR__ . '/../client');
+$path = realpath($clientBase . ($uri === '/' ? '/index.html' : $uri));
+if ($path && strpos($path, $clientBase) === 0 && is_file($path)) {
+    $mime = mime_content_type($path);
+    header('Content-Type: ' . $mime);
+    readfile($path);
+} else {
+    http_response_code(404);
+    echo 'Not Found';
+}
+?>


### PR DESCRIPTION
## Summary
- provide a simple component framework with manual refresh and animation helpers
- update the demo client to use the new framework
- adjust the example HTML and README for running the PHP server

## Testing
- `php -S localhost:8000 -t server index.php >/tmp/php.log 2>&1 &` *(fails: command not found)*
- `curl -s http://localhost:8000/api/hello`


------
https://chatgpt.com/codex/tasks/task_e_68458f97de948322bb4d60bccb1aba18