### PR TITLE
Improve Diagnose client styling

### DIFF
--- a/diagnose/client/app.js
+++ b/diagnose/client/app.js
@@ -1,4 +1,19 @@
-window.addEventListener('DOMContentLoaded', () => {
+(() => {
+  class SurveyService {
+    static async history() {
+      const res = await fetch('/api/history');
+      return res.json();
+    }
+
+    static async answer(index, value) {
+      return fetch('/api/answer', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ index, value })
+      });
+    }
+  }
+
   class SurveyComponent extends Framework.Component {
     constructor(root) {
       super(root);
@@ -7,10 +22,9 @@ window.addEventListener('DOMContentLoaded', () => {
       this.done = false;
     }
 
-    async fetchHistory() {
+    async refreshData() {
       try {
-        const res = await fetch('/api/history');
-        const data = await res.json();
+        const data = await SurveyService.history();
         this.questions = data.history;
         this.nextIndex = data.nextIndex;
         this.done = this.nextIndex >= this.questions.length;
@@ -20,13 +34,9 @@ window.addEventListener('DOMContentLoaded', () => {
       this.refresh();
     }
 
-    async sendAnswer(index, value) {
-      await fetch('/api/answer', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ index, value })
-      });
-      await this.fetchHistory();
+    async handleAnswer(index, value) {
+      await SurveyService.answer(index, value);
+      await this.refreshData();
     }
 
     template() {
@@ -49,7 +59,7 @@ window.addEventListener('DOMContentLoaded', () => {
         btn.addEventListener('click', () => {
           const index = parseInt(btn.dataset.index, 10);
           const val = parseInt(btn.dataset.value, 10);
-          this.sendAnswer(index, val);
+          this.handleAnswer(index, val);
         });
       });
       const newEl = this.root.querySelector(`.question[data-question-index="${this.nextIndex}"]`);
@@ -59,10 +69,10 @@ window.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  const root = document.getElementById('app');
-  
-  const survey = new SurveyComponent(root);
-  survey.fetchHistory();
-  survey.mount();
-  survey.fetchQuestion();
-});
+  window.addEventListener('DOMContentLoaded', () => {
+    const root = document.getElementById('app');
+    const survey = new SurveyComponent(root);
+    survey.mount();
+    survey.refreshData();
+  });
+})();

--- a/diagnose/client/index.html
+++ b/diagnose/client/index.html
@@ -1,13 +1,65 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Diagnose Client</title>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <script src="framework.js"></script>
   <script src="app.js"></script>
   <style>
-    #app { min-height: 1em; }
-    .question { margin-bottom: 1em; }
-    .scale button.selected { background: #0bf; color: #fff; }
+    body {
+      margin: 0;
+      font-family: 'Roboto', sans-serif;
+      background: linear-gradient(135deg, #eceff1, #f5f7fa);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      min-height: 100vh;
+      color: #333;
+    }
+    h1 {
+      margin-top: 40px;
+      font-weight: 400;
+    }
+    #app {
+      width: 90%;
+      max-width: 600px;
+    }
+    .question {
+      margin-bottom: 1.5em;
+      background: #fff;
+      padding: 1em;
+      border-radius: 8px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    .scale {
+      display: flex;
+      gap: 0.5em;
+      margin-top: 0.5em;
+    }
+    .scale button {
+      flex: 1;
+      padding: 0.5em 0;
+      border: 1px solid #bbb;
+      border-radius: 4px;
+      background: #f7f7f7;
+      cursor: pointer;
+      transition: background 0.2s, color 0.2s;
+    }
+    .scale button:hover {
+      background: #e0e0e0;
+    }
+    .scale button.selected {
+      background: #0bf;
+      color: #fff;
+      border-color: #0bf;
+    }
+    .thanks {
+      font-size: 1.4em;
+      text-align: center;
+      margin-top: 2em;
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- modernize Diagnose client styling with Google font and modern CSS rules
- refactor JavaScript client to use a small service class

## Testing
- `php -S localhost:8000 -t diagnose/public diagnose/public/index.php >/tmp/php.log 2>&1 &`
- `curl -s http://localhost:8000/api/hello`


------
https://chatgpt.com/codex/tasks/task_e_6845ed4f3cc88322955e8ed11ced960c