### PR TITLE
Update survey to MySQL

### DIFF
--- a/diagnose/app/front.html
+++ b/diagnose/app/front.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Create Questionnaire</title>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 2em; }
+    #link a { font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h1>Create Questionnaire</h1>
+  <button id="create">Create Link</button>
+  <p id="link"></p>
+  <script>
+    const alphabet = '23456789CFGHJMPQRVWX';
+    document.getElementById('create').addEventListener('click', () => {
+      let id = Array.from({length:8}, () => alphabet[Math.floor(Math.random()*alphabet.length)]).join('');
+      const link = '/survey/' + id;
+      document.getElementById('link').innerHTML = `<a href="${link}">${location.origin}${link}</a>`;
+    });
+  </script>
+</body>
+</html>

--- a/diagnose/app/index.html
+++ b/diagnose/app/index.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Diagnose Client</title>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
-  <script src="framework.js"></script>
-  <script src="service.js"></script>
-  <script src="component.js"></script>
-  <script src="main.js"></script>
+  <script src="/framework.js"></script>
+  <script src="/service.js"></script>
+  <script src="/component.js"></script>
+  <script src="/main.js"></script>
   <style>
     body {
       margin: 0;

--- a/diagnose/app/service.js
+++ b/diagnose/app/service.js
@@ -1,12 +1,16 @@
 (() => {
   class SurveyService {
+    static get surveyId() {
+      const m = location.pathname.match(/\/survey\/([A-Z0-9]+)/i);
+      return m ? m[1] : '';
+    }
     static async history() {
-      const res = await fetch('/api/history');
+      const res = await fetch(`/api/${SurveyService.surveyId}/history`);
       return res.json();
     }
 
     static async answer(index, value) {
-      return fetch('/api/answer', {
+      return fetch(`/api/${SurveyService.surveyId}/answer`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ index, value })

--- a/diagnose/public/index.php
+++ b/diagnose/public/index.php
@@ -1,28 +1,53 @@
 <?php
-session_start();
-
 $questions = require __DIR__ . '/questions.php';
 require __DIR__ . '/api.php';
 
+$pdo = new PDO('mysql:host=localhost;dbname=survey;charset=utf8mb4', 'root', '');
+
 $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
 
-switch ($uri) {
-    case '/api/hello':
-        handleHello();
+if ($uri === '/api/hello') {
+    handleHello();
+    return;
+}
+
+$parts = array_values(array_filter(explode('/', trim($uri, '/'))));
+
+if (isset($parts[0]) && $parts[0] === 'api' && count($parts) >= 2) {
+    $surveyId = $parts[1];
+    if (!preg_match('/^[23456789CFGHJMPQRVWX]{8}$/i', $surveyId)) {
+        http_response_code(400);
+        echo 'Invalid survey id';
         return;
-    case '/api/history':
-        handleHistory($questions);
-        return;
-    case '/api/question':
-        handleQuestion($questions);
-        return;
-    case '/api/answer':
-        handleAnswer($questions);
-        return;
+    }
+    $endpoint = $parts[2] ?? 'history';
+    switch ($endpoint) {
+        case 'hello':
+            handleHello();
+            break;
+        case 'history':
+            handleHistory($pdo, $surveyId, $questions);
+            break;
+        case 'question':
+            handleQuestion($pdo, $surveyId, $questions);
+            break;
+        case 'answer':
+            handleAnswer($pdo, $surveyId, $questions);
+            break;
+        default:
+            http_response_code(404);
+    }
+    return;
 }
 
 $clientBase = realpath(__DIR__ . '/../app');
-$path = realpath($clientBase . ($uri === '/' ? '/index.html' : $uri));
+if ($uri === '/') {
+    $path = realpath($clientBase . '/front.html');
+} elseif (preg_match('#^/survey/[23456789CFGHJMPQRVWX]{8}$#i', $uri)) {
+    $path = realpath($clientBase . '/index.html');
+} else {
+    $path = realpath($clientBase . $uri);
+}
 if ($path && strpos($path, $clientBase) === 0 && is_file($path)) {
     $mime = mime_content_type($path);
     header('Content-Type: ' . $mime);


### PR DESCRIPTION
## Summary
- add a front page to generate questionnaire links
- load survey id from URL and call new API routes
- store answers in a MySQL table instead of session
- serve `/survey/<id>` paths for the client
- keep `/api/hello` for the smoke test

## Testing
- `php -S localhost:8000 -t public public/index.php &`
- `curl -s http://localhost:8000/api/hello`

------
https://chatgpt.com/codex/tasks/task_e_6846a20e835083228d5f2bdf9aaf888b