### PR TITLE
Implement diagnostic survey logic

### DIFF
--- a/diagnose/public/api.php
+++ b/diagnose/public/api.php
@@ -7,11 +7,11 @@ function handleHello() {
 function handleHistory(PDO $pdo, string $surveyId, array $questions) {
     header('Content-Type: application/json');
 
-    $stmt = $pdo->prepare('SELECT question_index, answer FROM answers WHERE survey_id = ?');
+    $stmt = $pdo->prepare('SELECT symptom_id, answer FROM answers WHERE survey_id = ?');
     $stmt->execute([$surveyId]);
     $answers = [];
     while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-        $answers[$row['question_index']] = $row['answer'];
+        $answers[$row['symptom_id']] = $row['answer'];
     }
     $history = [];
     foreach ($questions as $i => $q) {
@@ -21,12 +21,7 @@ function handleHistory(PDO $pdo, string $surveyId, array $questions) {
             'answer' => $answers[$i] ?? null,
         ];
     }
-    $nextIndex = 0;
-    foreach ($answers as $idx => $val) {
-        if ($val !== null && $idx >= $nextIndex) {
-            $nextIndex = $idx + 1;
-        }
-    }
+    $nextIndex = selectNextIndex($pdo, $surveyId);
     echo json_encode([
         'history' => $history,
         'nextIndex' => $nextIndex,
@@ -35,11 +30,8 @@ function handleHistory(PDO $pdo, string $surveyId, array $questions) {
 
 function handleQuestion(PDO $pdo, string $surveyId, array $questions) {
     header('Content-Type: application/json');
-    $stmt = $pdo->prepare('SELECT MAX(question_index) AS m FROM answers WHERE survey_id = ?');
-    $stmt->execute([$surveyId]);
-    $max = $stmt->fetchColumn();
-    $index = $max === null ? 0 : ($max + 1);
-    if ($index < count($questions)) {
+    $index = selectNextIndex($pdo, $surveyId);
+    if ($index !== null && isset($questions[$index])) {
         echo json_encode(['question' => $questions[$index], 'index' => $index]);
     } else {
         echo json_encode(['done' => true]);
@@ -51,13 +43,44 @@ function handleAnswer(PDO $pdo, string $surveyId, array $questions) {
     $input = json_decode(file_get_contents('php://input'), true);
     $index = isset($input['index']) ? intval($input['index']) : null;
     $value = isset($input['value']) ? intval($input['value']) : null;
-    if ($index === null || $index < 0 || $index >= count($questions) ||
+    if ($index === null || !isset($questions[$index]) ||
         $value === null || $value < 1 || $value > 7) {
         http_response_code(400);
         echo json_encode(['error' => 'Invalid answer']);
         return;
     }
-    $stmt = $pdo->prepare('INSERT INTO answers (survey_id, question_index, answer) VALUES (?,?,?) ON DUPLICATE KEY UPDATE answer=VALUES(answer)');
+    $stmt = $pdo->prepare('INSERT INTO answers (survey_id, symptom_id, answer) VALUES (?,?,?) ON DUPLICATE KEY UPDATE answer=VALUES(answer)');
     $stmt->execute([$surveyId, $index, $value]);
     echo json_encode(['status' => 'ok']);
+}
+
+function handleScores(PDO $pdo, string $surveyId) {
+    header('Content-Type: application/json');
+    $scores = computeDiagnosisScores($pdo, $surveyId);
+    echo json_encode(['scores' => $scores]);
+}
+
+function computeDiagnosisScores(PDO $pdo, string $surveyId) {
+    $sql = 'SELECT d.id, d.name, COALESCE(SUM(a.answer * w.weight),0) AS score
+            FROM diagnoses d
+            LEFT JOIN weights w ON w.diagnosis_id = d.id
+            LEFT JOIN answers a ON a.symptom_id = w.symptom_id AND a.survey_id = ?
+            GROUP BY d.id, d.name
+            ORDER BY score DESC';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([$surveyId]);
+    return $stmt->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function selectNextIndex(PDO $pdo, string $surveyId) {
+    $sql = 'SELECT s.id
+            FROM symptoms s
+            LEFT JOIN answers a ON a.symptom_id = s.id AND a.survey_id = ?
+            WHERE a.symptom_id IS NULL
+            ORDER BY (SELECT VARIANCE(w.weight) FROM weights w WHERE w.symptom_id = s.id) DESC
+            LIMIT 1';
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([$surveyId]);
+    $idx = $stmt->fetchColumn();
+    return $idx === false ? null : intval($idx);
 }

--- a/diagnose/public/index.php
+++ b/diagnose/public/index.php
@@ -1,5 +1,4 @@
 <?php
-$questions = require __DIR__ . '/questions.php';
 require __DIR__ . '/api.php';
 
 $pdo = null;
@@ -14,6 +13,13 @@ if (file_exists($dbPath)) {
         '',
         [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
     );
+}
+
+// Load symptoms from the database
+$questions = [];
+$stmt = $pdo->query('SELECT id, question FROM symptoms ORDER BY id');
+while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+    $questions[$row['id']] = $row['question'];
 }
 
 $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
@@ -43,6 +49,9 @@ if (isset($parts[0]) && $parts[0] === 'api' && count($parts) >= 2) {
             break;
         case 'answer':
             handleAnswer($pdo, $surveyId, $questions);
+            break;
+        case 'scores':
+            handleScores($pdo, $surveyId);
             break;
         default:
             http_response_code(404);

--- a/diagnose/sql/create_answers.sql
+++ b/diagnose/sql/create_answers.sql
@@ -1,6 +1,48 @@
+-- Questions are stored as "symptoms".  Each symptom can contribute to multiple
+-- diagnoses using weights.
+
+CREATE TABLE symptoms (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  question TEXT NOT NULL
+);
+
+CREATE TABLE diagnoses (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(100) NOT NULL
+);
+
+-- Weight matrix connecting symptoms to diagnoses
+CREATE TABLE weights (
+  symptom_id INT NOT NULL,
+  diagnosis_id INT NOT NULL,
+  weight FLOAT NOT NULL,
+  PRIMARY KEY (symptom_id, diagnosis_id),
+  FOREIGN KEY (symptom_id) REFERENCES symptoms(id),
+  FOREIGN KEY (diagnosis_id) REFERENCES diagnoses(id)
+);
+
+-- Answers link a survey to a specific symptom rating
 CREATE TABLE answers (
   survey_id VARCHAR(8) NOT NULL,
-  question_index INT NOT NULL,
+  symptom_id INT NOT NULL,
   answer INT NOT NULL,
-  PRIMARY KEY (survey_id, question_index)
+  PRIMARY KEY (survey_id, symptom_id),
+  FOREIGN KEY (symptom_id) REFERENCES symptoms(id)
 );
+
+-- Example seed data
+INSERT INTO symptoms (question) VALUES
+  ('How satisfied are you with our service?'),
+  ('How likely are you to recommend us to a friend?'),
+  ('How would you rate the overall experience?');
+
+INSERT INTO diagnoses (name) VALUES
+  ('Great'),
+  ('Neutral'),
+  ('Poor');
+
+-- Simple weight matrix for demonstration purposes
+INSERT INTO weights (symptom_id, diagnosis_id, weight) VALUES
+  (1,1, 1.0), (1,2, 0.5), (1,3, -1.0),
+  (2,1, 1.0), (2,2, 0.2), (2,3, -0.5),
+  (3,1, 1.0), (3,2, 0.1), (3,3, -0.7);


### PR DESCRIPTION
## Summary
- define schema for symptoms, diagnoses and weights
- load symptoms from DB when the PHP server starts
- compute scores from answer-weight matrix
- choose questions based on weight variance

## Testing
- `php -S localhost:8000 -t public public/index.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6846cb6d0d308322a0456d5fa4f35659