### PR TITLE
Cleanup DB instructions and add setup script

### DIFF
--- a/diagnose/README.md
+++ b/diagnose/README.md
@@ -31,10 +31,10 @@ export DB_USER=root
 export DB_PASS=
 ```
 
-Create the table with:
+Initialize the database with all tables and seed data using:
 
 ```bash
-mysql -u$DB_USER -p$DB_PASS $DB_NAME < sql/create_answers.sql
+mysql -u$DB_USER -p$DB_PASS $DB_NAME < sql/setup.sql
 ```
 
 Then open [http://localhost:8000](http://localhost:8000) in your browser or run the `curl` command described in `AGENTS.md`.

--- a/diagnose/sql/setup.sql
+++ b/diagnose/sql/setup.sql
@@ -1,0 +1,5 @@
+-- Create tables and load data for the survey database
+SOURCE structure.sql;
+SOURCE symptoms.sql;
+SOURCE diagnoses.sql;
+SOURCE weights.sql;


### PR DESCRIPTION
## Summary
- add `sql/setup.sql` with SOURCE statements for structure and data
- fix README to point at new setup script

## Testing
- `php -S localhost:8000 -t public public/index.php &`
- `curl -s http://localhost:8000/api/hello`

------
https://chatgpt.com/codex/tasks/task_e_6846da88ea048322ae66a28301a09848