### PR TITLE
Add Diagnose 2.0 documentation

### DIFF
--- a/diagnose/README.md
+++ b/diagnose/README.md
@@ -2,6 +2,8 @@
 
 This subproject contains a PHP server with a static JavaScript client. The server exposes an API endpoint at `/api/hello` and survey endpoints for the client. The client uses a tiny component framework with animations and shows a questionnaire that grows as new questions arrive.
 
+See `docs/v2.0.md` for the latest 2.0 release notes.
+
 ## Running
 
 From the `diagnose` directory, start the built-in PHP server (you may need to install PHP with `sudo apt-get install php-cli php-mysql`):

--- a/diagnose/docs/v2.0.md
+++ b/diagnose/docs/v2.0.md
@@ -1,0 +1,21 @@
+# Diagnose 2.0 Documentation
+
+Diagnose 2.0 expands the survey system with sequential questions, built‑in scoring and a simplified database setup.
+
+## Key Features
+
+- **Sequential Question Flow** – Each new question is fetched only after the previous answer is stored so the survey adapts in real time.
+- **Dynamic Scoring** – Answers are weighted using the `weights` table to compute diagnosis scores through `/api/<id>/scores`.
+- **MySQL or SQLite** – The server first tries to connect to MySQL but falls back to an in‑memory SQLite database when MySQL is unavailable.
+- **Setup Script** – `sql/setup.sql` loads all tables and seed data in one command.
+
+## Usage
+
+1. From the `diagnose` directory start the server:
+   ```bash
+   php -S localhost:8000 -t public public/index.php
+   ```
+2. Visit `/` to create a questionnaire link or open `/survey/<id>` directly.
+3. Submit answers and retrieve scores using the `/api/<id>/scores` endpoint.
+
+See `README.md` for database configuration and additional endpoints.


### PR DESCRIPTION
## Summary
- add `docs/v2.0.md` with notes for version 2.0
- link release notes from the diagnose README

## Testing
- `php -S localhost:8000 -t public public/index.php &`
- `curl -s http://localhost:8000/api/hello`

------
https://chatgpt.com/codex/tasks/task_e_6846f07d19f48322bc9e7b951fe88f1d