### PR TITLE
Add information-theoretic question selection

### DIFF
--- a/diagnose/README.md
+++ b/diagnose/README.md
@@ -18,6 +18,23 @@ php -S localhost:8000 -t public public/index.php
 
 The questionnaire requests the next question automatically based on server state.
 
+## Efficiency-Aware Question Selection
+
+The API now chooses questions using a three-stage information-theoretic
+approach:
+
+1. **Stage 1 – Exploration**
+   - Picks the question with the highest expected entropy reduction across all
+     diagnoses.
+2. **Stage 2 – Differential Diagnosis**
+   - Focuses on the top three most probable diagnoses and again selects the
+     question with the highest expected gain among them.
+3. **Stage 3 – Confirmation**
+   - Prioritizes questions that best confirm or refute the leading diagnosis.
+
+The threshold for asking additional questions becomes stricter as more responses
+are recorded to keep surveys short when little new information is gained.
+
 Visit `/` to generate a new 8‑character questionnaire link. Opening `/survey/<id>` loads the questionnaire identified by `<id>`.
 
 ### Database

--- a/diagnose/public/api.php
+++ b/diagnose/public/api.php
@@ -68,15 +68,154 @@ function computeDiagnosisScores(PDO $pdo, string $surveyId) {
     return $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
+function loadWeightMatrix(PDO $pdo): array {
+    static $cache = null;
+    if ($cache !== null) {
+        return $cache;
+    }
+    $cache = [];
+    $stmt = $pdo->query('SELECT symptom_id, diagnosis_id, weight FROM weights');
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $s = (int)$row['symptom_id'];
+        $d = (int)$row['diagnosis_id'];
+        $cache[$s][$d] = (float)$row['weight'];
+    }
+    return $cache;
+}
+
+function softmax(array $scores, ?array $subset = null): array {
+    $max = null;
+    foreach ($scores as $id => $score) {
+        if ($subset !== null && !in_array($id, $subset, true)) {
+            continue;
+        }
+        $max = $max === null ? $score : max($max, $score);
+    }
+    $exp = [];
+    $sum = 0.0;
+    foreach ($scores as $id => $score) {
+        if ($subset !== null && !in_array($id, $subset, true)) {
+            continue;
+        }
+        $e = exp($score - $max);
+        $exp[$id] = $e;
+        $sum += $e;
+    }
+    $probs = [];
+    foreach ($exp as $id => $e) {
+        $probs[$id] = $e / $sum;
+    }
+    return $probs;
+}
+
+function entropy(array $probs): float {
+    $h = 0.0;
+    foreach ($probs as $p) {
+        if ($p > 0.0) {
+            $h -= $p * log($p, 2);
+        }
+    }
+    return $h;
+}
+
+function expectedGain(array $scores, array $weights, ?array $subset = null): float {
+    $H0 = entropy(softmax($scores, $subset));
+    $total = 0.0;
+    for ($v = 1; $v <= 7; $v++) {
+        $new = $scores;
+        foreach ($weights as $d => $w) {
+            if ($subset !== null && !in_array($d, $subset, true)) {
+                continue;
+            }
+            $new[$d] = ($new[$d] ?? 0) + $w * $v;
+        }
+        $total += entropy(softmax($new, $subset));
+    }
+    $H1 = $total / 7.0;
+    return $H0 - $H1;
+}
+
 function selectNextIndex(PDO $pdo, string $surveyId) {
-    $sql = 'SELECT s.id
-            FROM symptoms s
-            LEFT JOIN answers a ON a.symptom_id = s.id AND a.survey_id = ?
-            WHERE a.symptom_id IS NULL
-            ORDER BY (SELECT VARIANCE(w.weight) FROM weights w WHERE w.symptom_id = s.id) DESC
-            LIMIT 1';
-    $stmt = $pdo->prepare($sql);
+    $weights = loadWeightMatrix($pdo);
+
+    // Already answered questions
+    $stmt = $pdo->prepare('SELECT symptom_id FROM answers WHERE survey_id = ?');
     $stmt->execute([$surveyId]);
-    $idx = $stmt->fetchColumn();
-    return $idx === false ? null : intval($idx);
+    $answered = $stmt->fetchAll(PDO::FETCH_COLUMN);
+    $Q = count($answered);
+
+    // Candidates
+    $stmt = $pdo->query('SELECT id FROM symptoms');
+    $candidates = [];
+    while ($row = $stmt->fetch(PDO::FETCH_COLUMN)) {
+        if (!in_array($row, $answered)) {
+            $candidates[] = (int)$row;
+        }
+    }
+    if (!$candidates) {
+        return null;
+    }
+
+    // Current scores
+    $scores = computeDiagnosisScores($pdo, $surveyId);
+    $cur = [];
+    foreach ($scores as $row) {
+        $cur[(int)$row['id']] = (float)$row['score'];
+    }
+
+    $alpha = 0.5;
+    $beta = 0.2;
+    $threshold = $alpha * exp(-$beta * $Q);
+
+    // ----- Stage 1: global information -----
+    $best = [null, -INF];
+    foreach ($candidates as $sym) {
+        $gain = expectedGain($cur, $weights[$sym] ?? []);
+        if ($gain > $best[1]) {
+            $best = [$sym, $gain];
+        }
+    }
+    if ($best[1] >= $threshold) {
+        return $best[0];
+    }
+
+    // ----- Stage 2: top diagnoses -----
+    $probs = softmax($cur);
+    arsort($probs);
+    $topIds = array_slice(array_keys($probs), 0, 3);
+    $best = [null, -INF];
+    foreach ($candidates as $sym) {
+        $gain = expectedGain($cur, $weights[$sym] ?? [], $topIds);
+        if ($gain > $best[1]) {
+            $best = [$sym, $gain];
+        }
+    }
+    if ($best[1] >= $threshold) {
+        return $best[0];
+    }
+
+    // ----- Stage 3: confirm top diagnosis -----
+    $top = $topIds[0];
+    $best = [null, -INF];
+    foreach ($candidates as $sym) {
+        $w = $weights[$sym] ?? [];
+        $topW = abs($w[$top] ?? 0.0);
+        $alt = 0.0;
+        foreach ($w as $d => $val) {
+            if ($d == $top) {
+                continue;
+            }
+            $alt = max($alt, abs($val));
+        }
+        $diff = $topW - $alt;
+        if ($diff > $best[1]) {
+            $best = [$sym, $diff];
+        }
+    }
+
+    if ($best[1] >= $threshold) {
+        return $best[0];
+    }
+
+    return null;
 }


### PR DESCRIPTION
## Summary
- implement multi-stage diagnostic algorithm in `api.php`
- document efficiency-aware approach in `diagnose/README.md`

## Testing
- `php -S localhost:8000 -t diagnose/public diagnose/public/index.php &`
- `curl -s http://localhost:8000/api/hello`

------
https://chatgpt.com/codex/tasks/task_e_68485236dd48832290c1989a79b77f89