### PR TITLE
Optimize questionnaire data loading

### DIFF
--- a/diagnose/app/component.js
+++ b/diagnose/app/component.js
@@ -8,9 +8,11 @@
 
     async refreshData() {
       try {
-        const hist = await SurveyService.history();
+        const [hist, next] = await Promise.all([
+          SurveyService.history(),
+          SurveyService.question(),
+        ]);
         this.questions = hist.history;
-        const next = await SurveyService.question();
         if (!next.done) {
           this.questions.push({ index: next.index, question: next.question, answer: null });
           this.done = false;


### PR DESCRIPTION
## Summary
- parallelize history and next question fetches in SurveyComponent

## Testing
- `php -S localhost:8000 -t public public/index.php &`
- `curl -s http://localhost:8000/api/hello`

------
https://chatgpt.com/codex/tasks/task_e_684856de57548322831eea2a1dc949d6